### PR TITLE
Create classname based on file type and add to container

### DIFF
--- a/GifLinks.js
+++ b/GifLinks.js
@@ -129,9 +129,11 @@ var GifLinks = (function() {
   function startPartying( element ) {
 
     var awesomeGif = element.getAttribute( 'data-src' );
+    var awesomeGifClass = awesomeGif.substring(0,awesomeGif.length-4);
     if( awesomeGif ) {
       container.style[ 'backgroundImage' ] = 'url(' + awesomeGif + ')';
       container.style[ 'display' ] = 'block';
+      container.className = awesomeGifClass;
     } else {
       console.log( "Sorry, an element doesn't have a data-src!" );
     }


### PR DESCRIPTION
wanted to apply different classes to my different giflinks, so created a classname from the data-src and removed the 4-char filetype. only downside is that using substring 0 means it doesn't pull out any file paths. I did it manually in my local version but wasn't sure how to go about doing that for a general implementation where the file path could be any number of characters. 

just figured I'd share if it might be useful! :)
